### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Authometion-MiLight/keywords.txt
+++ b/Authometion-MiLight/keywords.txt
@@ -6,7 +6,7 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-MiLight KEYWORD1
+MiLight	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -14,7 +14,7 @@ MiLight KEYWORD1
 
 initialize 	KEYWORD2
 setRadioTransmission	KEYWORD2
-setDefaultRadioTransmission KEYWORD2
+setDefaultRadioTransmission	KEYWORD2
 RGBWAndWhiteSendCommand	KEYWORD2
 RGBWOn	KEYWORD2
 WhiteOn	KEYWORD2
@@ -28,7 +28,7 @@ RGBWClearAddress	KEYWORD2
 WhiteClearAddress	KEYWORD2
 RGBWSetRGBValue	KEYWORD2
 WhiteSetTemperatureValue	KEYWORD2
-WhiteSetBrightnessValue	KEYWORD2    
+WhiteSetBrightnessValue	KEYWORD2
 WhiteActiveNightMode	KEYWORD2
 RGBWSetBrightnessValue	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords